### PR TITLE
Refactor healthchecks to use shared webProxy and resticBackup modules

### DIFF
--- a/nixos/hosts/windrunner/healthchecks.nix
+++ b/nixos/hosts/windrunner/healthchecks.nix
@@ -1,21 +1,6 @@
 { config, ... }:
 {
   sops.secrets = {
-    "healthchecks/restic/passwordFile" = {
-      owner = "root";
-      group = "root";
-      mode = "0600";
-    };
-    "healthchecks/restic/repositoryFile" = {
-      owner = "root";
-      group = "root";
-      mode = "0600";
-    };
-    "healthchecks/restic/environmentFile" = {
-      owner = "root";
-      group = "root";
-      mode = "0600";
-    };
     "healthchecks/SECRET_KEY_FILE" = {
       owner = config.services.healthchecks.user;
       group = config.services.healthchecks.group;
@@ -31,40 +16,18 @@
     };
   };
 
-  services.frp.settings.proxies = [
-    {
-      name = "HTTP healthchecks.albinvass.se";
-      customDomains = [ "healthchecks.albinvass.se" ];
-      type = "http";
-      localIP = config.networking.hostName;
-      localPort = config.services.nginx.defaultHTTPListenPort;
-    }
-    {
-      name = "HTTPS healthchecks.albinvass.se";
-      customDomains = [ "healthchecks.albinvass.se" ];
-      type = "https";
-      localIP = config.networking.hostName;
-      localPort = config.services.nginx.defaultSSLListenPort;
-      transport.proxyProtocolVersion = "v2";
-    }
-  ];
+  albinvass.resticBackup.services.healthchecks = {
+    paths = [ "/var/lib/healthchecks" ];
+    backupPrepareCommand = "systemctl stop healthchecks";
+    backupCleanupCommand = "systemctl start healthchecks";
+  };
 
-  services.nginx.virtualHosts = {
-    "healthchecks.albinvass.se" = {
-      forceSSL = true;
-      enableACME = true;
-      locations."/" = {
-        proxyPass = "http://127.0.0.1:8000";
-        proxyWebsockets = true;
-        extraConfig = ''
-          proxy_set_header        Host $host;
-          proxy_set_header        X-Real-IP $proxy_protocol_addr;
-          proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header        X-Forwarded-Proto $scheme;
-          proxy_set_header        X-Forwarded-Host $host;
-          proxy_set_header        X-Forwarded-Server $host;
-        '';
-      };
+  albinvass.webProxy.services."healthchecks.albinvass.se" = {
+    backend = {
+      host = "127.0.0.1";
+      port = 8000;
     };
+    ssl = true;
+    websockets = true;
   };
 }


### PR DESCRIPTION
Replace manually-defined nginx virtualHost and frp proxy entries with albinvass.webProxy.services, consistent with all other services. Also add albinvass.resticBackup.services.healthchecks to wire up the restic backup (removing the now-redundant manually-declared restic sops secrets which the module manages automatically).

https://claude.ai/code/session_014dDRd8qrZMMXEpvXYJNKQk